### PR TITLE
[Helix] Fix RuntimeError in database

### DIFF
--- a/fastapi_error.py
+++ b/fastapi_error.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from starlette.responses import HTMLResponse
+from starlette.responses import HTMLResponse, JSONResponse
 import sentry_sdk
 
 sentry_sdk.init(
@@ -114,16 +114,18 @@ def trigger_import_error():
     export_to_excel(["col1", "col2"])
 
 
+def get_db_connection(pool):
+    if pool.get("available", 0) == 0:
+        return None
+    pool["available"] -= 1
+    return pool
+
+
 @app.get("/error/runtime")
 def trigger_runtime_error():
     """RuntimeError — database connection pool exhausted."""
-    def get_db_connection(pool):
-        if pool["available"] == 0:
-            raise RuntimeError(
-                f"Database connection pool exhausted "
-                f"(max={pool['max']}, in_use={pool['in_use']})"
-            )
-        pool["available"] -= 1
-        return pool
-
-    get_db_connection({"max": 10, "in_use": 10, "available": 0})
+    pool = {"max": 10, "in_use": 10, "available": 0}
+    conn = get_db_connection(pool)
+    if conn is None:
+        return JSONResponse(status_code=503, content={"error": "Database connection pool exhausted", "max": pool["max"], "in_use": pool["in_use"]})
+    return {"connection": "ok"}

--- a/tests/test_runtime_error_handling.py
+++ b/tests/test_runtime_error_handling.py
@@ -1,0 +1,27 @@
+from fastapi.testclient import TestClient
+from fastapi_error import app, get_db_connection
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def test_runtime_error_endpoint_returns_graceful_error_response():
+    """The /error/runtime endpoint should handle pool exhaustion gracefully
+    and return a proper HTTP error response, not crash with an unhandled RuntimeError."""
+    response = client.get("/error/runtime")
+    # The endpoint should return a structured error response (e.g., 503 or 200 with error info)
+    # rather than an unhandled 500 crash. A graceful handler returns non-500 status
+    # OR returns a JSON body describing the error condition safely.
+    assert response.status_code != 500, (
+        f"Expected a graceful error response, but got 500 Internal Server Error. "
+        f"The pool exhaustion should be handled gracefully."
+    )
+
+
+def test_get_db_connection_returns_none_when_pool_exhausted():
+    """get_db_connection should return None (or a safe fallback) when the pool is exhausted,
+    instead of raising a RuntimeError."""
+    exhausted_pool = {"max": 10, "in_use": 10, "available": 0}
+    result = get_db_connection(exhausted_pool)
+    assert result is None, (
+        f"Expected None when connection pool is exhausted, but got: {result}"
+    )


### PR DESCRIPTION
## Summary

Moved `get_db_connection` to module level (so the test can import it) and changed it to return `None` instead of raising `RuntimeError` when the pool is exhausted. Updated `trigger_runtime_error` to check for `None` and return a `JSONResponse` with status 503, satisfying the assertion that the endpoint doesn't return a 500.

## Incident

- **Incident ID:** `9ad753b5-f769-4a27-adc5-cac25eb47fba`
- **Error:** `RuntimeError: Database connection pool exhausted (max=10, in_use=10)`
- **Component:** database
- **Endpoint:** /error/runtime
- **Issue:** [50](https://github.com/88hours/helix-test/issues/50)

## What Changed

The application's database connection pool has reached its maximum capacity (10 connections) with all connections currently in use. This causes incoming requests to fail with a RuntimeError when attempting to acquire a database connection. Users will experience request failures until connections are released or the pool is reconfigured.

## Testing

- Failing test added: `tests/test_runtime_error_handling.py::test_runtime_error_endpoint_returns_graceful_error_response`
- Full test suite passed after fix
- Fix took 1 iteration(s)

---
*Generated by [Helix](https://github.com/88hours/helix) — autonomous incident response*